### PR TITLE
Add Scalekit to OpenID Providers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@
 - [Pocket ID](https://github.com/pocket-id/pocket-id) - A simple OpenID Connect Provider that allows users to authenticate with their passkeys.
 - [SiteMinder](https://www.broadcom.com/products/identity/siteminder) - An IAM provided by Broadcom with OpenID Connect Provider support.
 - [SSOJet](https://ssojet.com) - A OpenID Connect based solution that seamlessly integrates enterprise SSO into your B2B SaaS. 
+- [Scalekit](https://scalekit.com) - Enterprise SSO platform with OIDC, SAML, SCIM provisioning, and OAuth token vault for AI agents (Agent Auth) and MCP server authorization.
 - [Transmit Security](https://developer.transmitsecurity.com/guides/user/auth_oidc/) - A CIAM solution that supports an OpenID Connect-based integration.
 - [WSO2 Identity Server](https://wso2.com/identity-server/) - Identity Server which provides modern identity and access management capabilities that can be easily built into organization's customer experience (CX) applications.
 - [Zitadel](https://github.com/zitadel/zitadel) - Open Source Identity solution with OpenID Connect provider (OP) and SAMLv2 ready to use.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@
 - [Pocket ID](https://github.com/pocket-id/pocket-id) - A simple OpenID Connect Provider that allows users to authenticate with their passkeys.
 - [SiteMinder](https://www.broadcom.com/products/identity/siteminder) - An IAM provided by Broadcom with OpenID Connect Provider support.
 - [SSOJet](https://ssojet.com) - A OpenID Connect based solution that seamlessly integrates enterprise SSO into your B2B SaaS. 
-- [Scalekit](https://scalekit.com) - Enterprise SSO platform with OIDC, SAML, SCIM provisioning, and OAuth token vault for AI agents (Agent Auth) and MCP server authorization.
+- [Scalekit](https://docs.scalekit.com/authenticate/sso/add-modular-sso/) - OpenID Connect provider for B2B applications, acting as the application's OpenID Provider (OP) for hosted enterprise SSO.
 - [Transmit Security](https://developer.transmitsecurity.com/guides/user/auth_oidc/) - A CIAM solution that supports an OpenID Connect-based integration.
 - [WSO2 Identity Server](https://wso2.com/identity-server/) - Identity Server which provides modern identity and access management capabilities that can be easily built into organization's customer experience (CX) applications.
 - [Zitadel](https://github.com/zitadel/zitadel) - Open Source Identity solution with OpenID Connect provider (OP) and SAMLv2 ready to use.


### PR DESCRIPTION
## What

Adds [Scalekit](https://scalekit.com) to the **OpenID Providers (OP)** section.

## Why

Scalekit is an enterprise SSO platform that supports OpenID Connect and OAuth 2.1 as a core capability:

- **OIDC provider**: Full OpenID Connect implementation for enterprise and B2B use cases
- **SAML & SCIM**: Enterprise identity federation + user provisioning
- **Agent Auth**: OAuth token vault for AI agents to call third-party APIs on behalf of users (100+ providers)
- **MCP Auth**: OAuth 2.1 authorization for MCP servers

Scalekit sits alongside Auth0, Clerk, and Okta in this section as a SaaS OIDC provider. Its differentiator is native AI agent support (Agent Auth + MCP Auth) which makes it relevant as agentic workloads increasingly need secure identity infrastructure.

## Entry Added

```markdown
- [Scalekit](https://scalekit.com) - Enterprise SSO platform with OIDC, SAML, SCIM provisioning, and OAuth token vault for AI agents (Agent Auth) and MCP server authorization.
```