### PR TITLE
add authsome under Relying Parties (RP) Software Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@
 ## Relying Parties (RP) Software Plugins
 
 - [MiniOrange OAuth SSO](https://wordpress.org/plugins/miniorange-login-with-eve-online-google-facebook/) - Wordpress OAuth and OpenID Connect plugin developed and actively maintained by MiniOrange.
+- [authsome](https://github.com/agentrhq/authsome) - Local credential broker for AI agents that implements OpenID Connect Relying Party flows (browser PKCE and device code) for 14 OAuth2 providers including Google, GitHub, Microsoft, Slack, Notion, and Linear. Encrypted local vault, background token refresh, and a local HTTPS proxy that injects tokens into outbound provider requests so the calling agent process never holds raw secrets. Python 3.13+, MIT.
 
 ## Resources
 


### PR DESCRIPTION
hey, opening this to add authsome under Relying Parties (RP) Software Plugins.

authsome implements OpenID Connect Relying Party flows (browser PKCE and device code) on behalf of AI agents. log in once via the user's browser, the encrypted local vault stores the resulting tokens, a local HTTPS proxy refreshes them in the background and injects access tokens into outbound provider requests so the calling agent process never holds raw secrets.

14 OAuth2 providers bundled, most of which have OIDC support: google, github, microsoft, slack, notion, linear, hubspot, atlassian, etc. plus 31 plain API-key providers. all implemented as JSON provider definitions, so users can add new OIDC providers without changing the codebase.

fits under "RP Software Plugins" because authsome plays the RP role on the user's machine, mediating between the OIDC providers and the AI agent (which is the actual consumer of the token). happy to reword the entry or move it to a more specific section if you have one for client-side OIDC tooling.

repo: https://github.com/agentrhq/authsome
website: https://authsome.ai
license: MIT
docs: https://authsome.ai/docs